### PR TITLE
Also build avfilter and swresample! 🤓

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Actions Status](https://github.com/rust-av/libav-rs/workflows/libav/badge.svg)](https://github.com/rust-av/libav-rs/actions)
 
-It is a simple [binding][1] and safe abstraction over [libav][2] avcodec, avformat and avresample.
+It is a simple [binding][1] and safe abstraction over [libav][2] avcodec, avformat, avfilter, avresample, and swresample.
 
 ## Building
 

--- a/libav-sys/.gitignore
+++ b/libav-sys/.gitignore
@@ -1,4 +1,6 @@
 src/avformat.rs
 src/avcodec.rs
 src/avresample.rs
+src/avfilter.rs
+src/swresample.rs
 target/

--- a/libav-sys/Cargo.toml
+++ b/libav-sys/Cargo.toml
@@ -15,6 +15,8 @@ metadeps = "1.1"
 [package.metadata.pkg-config]
 libavcodec = "58"
 libavformat = "58"
+libavfilter = "7.40.101"
 libavresample = "4.0.0"
+libswresample = "3.3.100"
 
 [dependencies]

--- a/libav-sys/build.rs
+++ b/libav-sys/build.rs
@@ -29,7 +29,7 @@ fn common_builder() -> bindgen::Builder {
 fn main() {
     let libs = metadeps::probe().unwrap();
 
-    for e in ["avcodec", "avformat", "avresample"].iter() {
+    for e in ["avcodec", "avfilter", "avformat", "avresample", "swresample"].iter() {
         let headers = libs
             .get(&format!("lib{}", e))
             .unwrap()

--- a/libav-sys/data/libavfilter.h
+++ b/libav-sys/data/libavfilter.h
@@ -1,0 +1,1 @@
+#include <libavfilter/avfilter.h>

--- a/libav-sys/data/libswresample.h
+++ b/libav-sys/data/libswresample.h
@@ -1,0 +1,1 @@
+#include <libswresample/swresample.h>

--- a/libav-sys/src/lib.rs
+++ b/libav-sys/src/lib.rs
@@ -3,7 +3,9 @@
 
 pub mod avcodec;
 pub mod avformat;
+pub mod avfilter;
 pub mod avresample;
+pub mod swresample;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This completes all the functionality I needed from these bindings, even though there are a few more `libav` libraries that may be compiled in.

But I do have some working (unsafe) rust code for decoding network audio using `libav-rs`, I would like to contribute it as an example, if you wish.